### PR TITLE
Change port configuration

### DIFF
--- a/diyhue/config.json
+++ b/diyhue/config.json
@@ -7,18 +7,8 @@
 "panel_icon": "mdi:home-lightbulb",
 "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
 "ports": {
-    "80/tcp": 80,
-    "443/tcp": 443,
-    "1900/udp": 1901,
-    "1982/udp": 1982,
-    "2100/udp": 2100
 },
 "ports_description": {
-    "80/tcp": "Hue API",
-    "443/tcp": "Hue API SSL",
-    "1900/udp": "ssdp discover",
-    "1982/udp": "Yeelight detection",
-    "2100/udp": "Hue Entertainment"
 },
 "auth_api": true,
 "hassio_api": true,
@@ -30,13 +20,17 @@
     "mac": "xx:xx:xx:xx:xx:xx",
     "debug": false,
     "deconz_ip": "",
-    "no_serve_https": false
+    "no_serve_https": false,
+    "http_port": 80,
+    "https_port": 443
 },
 "schema": {
     "config_path": "str",
     "mac": "str",
     "debug": "bool",
     "deconz_ip": "str",
-    "no_serve_https": "bool"
+    "no_serve_https": "bool",
+    "http_port": "int",
+    "https_port": "int"
 }
 }

--- a/diyhue/rootfs/run.sh
+++ b/diyhue/rootfs/run.sh
@@ -5,6 +5,10 @@ CONFIG_PATH=/data/options.json
 export MAC="$(bashio::config 'mac')"
 export CONFIG_PATH="$(bashio::config 'config_path')"
 export DEBUG="$(bashio::config 'debug')"
+export HTTP_PORT="$(bashio::config 'http_port')"
+export HTTPS_PORT="$(bashio::config 'https_port')"
+
+
 
 if [[ ! -z "$(bashio::config 'deconz_ip')" ]]; then
     export DECONZ="$(bashio::config 'deconz_ip')"


### PR DESCRIPTION
https://github.com/diyhue/hassio-addon/issues/5

As this add on runs in host network mode the port configuration shouldn't be in use so I've removed it in this PR.

I've then made the HTTP / HTTPS ports configurable. This allows me to run NGINX on ports 80/443 and forward these to the addon on different ports (I used 41080 and 41443 for testing).

This all worked and I partially got the Home Assistant connection working but I think there are some bugs there as well. 